### PR TITLE
Improved and additional test cases. Added sampling 1 at a time function.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,18 +13,19 @@ all: clean lint test
 lint: 
 	@echo "========== Linting =========="
 	$(LINT) --ignore=$(IGNORE) --show-source *.py
-	@echo ""
+	@echo "\n"
 
 lint-full:
 	@echo "========== Linting =========="
 	$(LINT) --show-source --statistics *.py
-	@echo ""
+	@echo "\n"
 
 test: multivariate_hypergeometric.py test.py
 	@echo "========== Testing =========="
 	$(PY) test.py
-	@echo ""
+	@echo "\n"
 
 clean: 
 	@echo "========== Cleaning ========="
 	find . -name "*.pyc"7 -delete -print
+	@echo "\n"

--- a/multivariate_hypergeometric.py
+++ b/multivariate_hypergeometric.py
@@ -91,6 +91,9 @@ class MultivarHG(object):
                     counts must be List[int] or Dict[str, int]')
 
         if total:
+            if sum(self.init_counts) != total:
+                raise ValueError('Total must be equal to the sum of \
+                        all object counts')
             self.init_total = total
             self.curr_total = total
         else:

--- a/multivariate_hypergeometric.py
+++ b/multivariate_hypergeometric.py
@@ -12,8 +12,6 @@ from typing import Union
 from typing import List
 from typing import Dict
 
-InputDist = Union[List[int], Dict[str, int]]
-
 
 class MultivarHG(object):
     """
@@ -64,8 +62,8 @@ class MultivarHG(object):
         integer values, should be equal to sum of those counts.
         """
         if type(counts) is list and all(isinstance(n, int) for n in counts):
-            self.init_counts = counts
-            self.curr_counts = counts
+            self.init_counts = list(counts)
+            self.curr_counts = list(counts)
 
             if names:
                 if len(names) != len(counts):
@@ -73,13 +71,17 @@ class MultivarHG(object):
                             type names and counts must be equal length')
 
                 self.type_names = names
+            else:
+                self.type_names = list()
+                for i in range(len(counts)):
+                    self.type_names.append(str(i))
 
         elif type(counts) is dict \
                 and all(isinstance(k, str) for k in counts.keys()) \
                 and all(isinstance(v, int) for v in counts.values()):
-            self.init_counts = counts.values()
-            self.curr_counts = counts.values()
-            self.type_names = counts.keys()
+            self.init_counts = list(counts.values())
+            self.curr_counts = list(counts.values())
+            self.type_names = list(counts.keys())
             if names:
                 raise Exception('Too may arguments: \
                         type names input in counts and names')
@@ -100,14 +102,16 @@ class MultivarHG(object):
     def __repr__(self):
         return 'MultivarHG({},{},{})'.format(self.type_names,
                                              self.curr_counts,
-                                             self.curr_total)
+                                             self.curr_total
+                                             )
 
     def __str__(self):
         return 'Types: {} \n \
                 Counts: {} \n \
                 Total: {}'.format(self.type_names,
                                   self.curr_counts,
-                                  self.curr_total)
+                                  self.curr_total
+                                  )
 
     def cdf(self) -> np.ndarray:
         """
@@ -117,7 +121,7 @@ class MultivarHG(object):
         proportions of items up to that point.
         """
         props = np.array([self.curr_counts[i]/self.curr_total
-                         for i in range(len(self.curr_counts))],
+                         for i in range(self.type_num)],
                          dtype=float)
         return np.array([sum(props[:i+1]) for i in range(self.type_num)])
 
@@ -155,11 +159,29 @@ class MultivarHG(object):
 
         return sample_counts
 
+    def sample1(self) -> str:
+        """
+        Sample 1 item from current distribution.
+
+        @return: item type (as string) of 1 sampled item.
+        """
+        if self.curr_total == 0:
+            raise Exception('Empty sample space')
+        cdf = self.cdf()
+        rv = np.random.random()
+        for i in range(self.type_num):
+            if rv < cdf[i] and self.curr_counts[i] > 0:
+                self.curr_counts[i] -= 1
+                self.curr_total -= 1
+                return self.type_names[i]
+        return None
+
     def reset(self) -> None:
         """Resets distribution to initial state."""
         if self.init_total == 0 or self.init_counts is None:
             raise Exception('Instantiation Error: \
-                            initial values not stored correctly')
-
+                    initial values not stored correctly')
         self.curr_total = self.init_total
-        self.curr_counts = self.init_counts
+        for i in range(self.type_num):
+            self.curr_counts[i] = self.init_counts[i]
+        return None

--- a/multivariate_hypergeometric.py
+++ b/multivariate_hypergeometric.py
@@ -106,12 +106,10 @@ class MultivarHG(object):
                                              )
 
     def __str__(self):
-        return 'Types: {} \n \
-                Counts: {} \n \
-                Total: {}'.format(self.type_names,
-                                  self.curr_counts,
-                                  self.curr_total
-                                  )
+        return 'Types: {} \nCounts: {} \nTotal: {}'.format(self.type_names,
+                                                           self.curr_counts,
+                                                           self.curr_total
+                                                           )
 
     def cdf(self) -> np.ndarray:
         """

--- a/test.py
+++ b/test.py
@@ -100,12 +100,9 @@ class TestStrMethods(unittest.TestCase):
         test1 = MultivarHG([10, 20, 30])
         test2 = MultivarHG([10, 20, 30], names=['First', 'Second', 'Third'])
         test3 = MultivarHG({'One': 1, 'Two': 2, 'Three': 3})
-        self.assertEqual(test1.__repr__(),
-                         'MultivarHG([\'0\', \'1\', \'2\'],[10, 20, 30],60)')
-        self.assertEqual(test2.__repr__(),
-                         'MultivarHG([\'First\', \'Second\', \'Third\'],[10, 20, 30],60)')
-        self.assertEqual(test3.__repr__(),
-                         'MultivarHG([\'One\', \'Two\', \'Three\'],[1, 2, 3],6)')
+        self.assertEqual(test1.__repr__(), 'MultivarHG([\'0\', \'1\', \'2\'],[10, 20, 30],60)')
+        self.assertEqual(test2.__repr__(), 'MultivarHG([\'First\', \'Second\', \'Third\'],[10, 20, 30],60)')
+        self.assertEqual(test3.__repr__(), 'MultivarHG([\'One\', \'Two\', \'Three\'],[1, 2, 3],6)')
 
     def test_str(self):
         test1 = MultivarHG([10, 20, 30])

--- a/test.py
+++ b/test.py
@@ -112,9 +112,14 @@ class TestStrMethods(unittest.TestCase):
 
 
 class TestCDFMethod(unittest.TestCase):
-    # TODO
-    def test(self):
-        return None
+    # TODO more aggressive testing
+    def test_simple(self):
+        test1 = MultivarHG([10, 20, 30])
+        test2 = MultivarHG({'A': 40, 'B': 100, 'C': 60})
+        cdf1 = list(test1.cdf())
+        cdf2 = list(test2.cdf())
+        self.assertListEqual(cdf1, [float(1 / 6), float(3 / 6), float(6 / 6)])
+        self.assertListEqual(cdf2, [float(4 / 20), float(14 / 20), float(20 / 20)])
 
 
 if __name__ == '__main__':

--- a/test.py
+++ b/test.py
@@ -49,7 +49,7 @@ class TestSamplingMethod(unittest.TestCase):
         test.sample(6)
         self.assertRaises(Exception, test.sample, 2)
 
-    def simple(self):
+    def simple_list(self):
         test1 = MultivarHG([10, 20, 30])
         sample1 = test1.sample(30)
         self.assertTrue(bool(sum(sample1) == 30))
@@ -57,11 +57,38 @@ class TestSamplingMethod(unittest.TestCase):
         self.assertTrue(bool(sample1[1] >= 0 and sample1[1] <= 20))
         self.assertTrue(bool(sample1[2] >= 0 and sample1[2] <= 30))
 
+    def simple_dict(self):
+        test1 = MultivarHG({'A': 10, 'B': 20, 'C': 30})
+        sample1 = test.sample(30)
+        self.assertTrue(bool(sum(sample1) == 30))
+        self.assertTrue(bool(sample1[0] >= 0 and sample1[0] <= 10))
+        self.assertTrue(bool(sample1[1] >= 0 and sample1[1] <= 20))
+        self.assertTrue(bool(sample1[2] >= 0 and sample1[2] <= 30))
+
+    def test_sample1(self):
+        test1 = MultivarHG({'A': 10, 'B': 10})
+        test2 = MultivarHG([10, 10], names=['A', 'B'])
+        test3 = MultivarHG([10, 10])
+        for i in range(20):
+            sample1 = test1.sample1()
+            sample2 = test2.sample1()
+            sample3 = test3.sample1()
+            self.assertTrue(bool(sample1 is 'A' or sample1 is 'B'))
+            self.assertTrue(bool(sample2 is 'A' or sample2 is 'B'))
+            self.assertTrue(bool(int(sample3) == 1 or int(sample3) == 0))
+
 
 class TestResetMethod(unittest.TestCase):
-    # TODO
+    # TODO: test exceptions from poor initialization
     def test(self):
-        return None
+        test1 = MultivarHG([10, 20, 30])
+        test1.sample(20)
+        self.assertNotEqual(test1.curr_total, 60)
+        test1.reset()
+        self.assertEqual(test1.curr_total, 60)
+        self.assertEqual(test1.curr_counts[0], 10)
+        self.assertEqual(test1.curr_counts[1], 20)
+        self.assertEqual(test1.curr_counts[2], 30)
 
 
 class TestStrMethods(unittest.TestCase):

--- a/test.py
+++ b/test.py
@@ -30,11 +30,14 @@ class TestCreationMethod(unittest.TestCase):
 
     def test_exceptions(self):
         self.assertRaises(Exception, MultivarHG, [0], names=[' ', ' '])
+        self.assertRaises(Exception, MultivarHG, [0, 1, 2], names=[' ', ' '])
         self.assertRaises(Exception, MultivarHG, {'A': 0}, names=[' '])
         self.assertRaises(TypeError, MultivarHG, [0.5])
         self.assertRaises(TypeError, MultivarHG, [' '])
         self.assertRaises(TypeError, MultivarHG, {'A': 0.5})
         self.assertRaises(TypeError, MultivarHG, {'A': 'a'})
+        self.assertRaises(ValueError, MultivarHG, [1, 2], total=1)
+        self.assertRaises(ValueError, MultivarHG, [10, 20], total=100)
 
 
 class TestSamplingMethod(unittest.TestCase):
@@ -92,9 +95,23 @@ class TestResetMethod(unittest.TestCase):
 
 
 class TestStrMethods(unittest.TestCase):
-    # TODO
-    def test(self):
-        return None
+
+    def test_repr(self):
+        test1 = MultivarHG([10, 20, 30])
+        test2 = MultivarHG([10, 20, 30], names=['First', 'Second', 'Third'])
+        test3 = MultivarHG({'One': 1, 'Two': 2, 'Three': 3})
+        self.assertEqual(test1.__repr__(),
+                         'MultivarHG([\'0\', \'1\', \'2\'],[10, 20, 30],60)')
+        self.assertEqual(test2.__repr__(),
+                         'MultivarHG([\'First\', \'Second\', \'Third\'],[10, 20, 30],60)')
+        self.assertEqual(test3.__repr__(),
+                         'MultivarHG([\'One\', \'Two\', \'Three\'],[1, 2, 3],6)')
+
+    def test_str(self):
+        test1 = MultivarHG([10, 20, 30])
+        test2 = MultivarHG([10, 20, 30], names=['First', 'Second', 'Third'])
+        test3 = MultivarHG({'One': 1, 'Two': 2, 'Three': 3})
+        # TODO
 
 
 class TestCDFMethod(unittest.TestCase):

--- a/test.py
+++ b/test.py
@@ -108,11 +108,13 @@ class TestStrMethods(unittest.TestCase):
         test1 = MultivarHG([10, 20, 30])
         test2 = MultivarHG([10, 20, 30], names=['First', 'Second', 'Third'])
         test3 = MultivarHG({'One': 1, 'Two': 2, 'Three': 3})
-        # TODO
+        self.assertEqual(test1.__str__(), 'Types: [\'0\', \'1\', \'2\'] \nCounts: [10, 20, 30] \nTotal: 60')
+        self.assertEqual(test2.__str__(), 'Types: [\'First\', \'Second\', \'Third\'] \nCounts: [10, 20, 30] \nTotal: 60')
+        self.assertEqual(test3.__str__(), 'Types: [\'One\', \'Two\', \'Three\'] \nCounts: [1, 2, 3] \nTotal: 6')
 
 
 class TestCDFMethod(unittest.TestCase):
-    # TODO more aggressive testing
+
     def test_simple(self):
         test1 = MultivarHG([10, 20, 30])
         test2 = MultivarHG({'A': 40, 'B': 100, 'C': 60})
@@ -120,6 +122,17 @@ class TestCDFMethod(unittest.TestCase):
         cdf2 = list(test2.cdf())
         self.assertListEqual(cdf1, [float(1 / 6), float(3 / 6), float(6 / 6)])
         self.assertListEqual(cdf2, [float(4 / 20), float(14 / 20), float(20 / 20)])
+
+    def test_large(self):
+        # TODO: tests for large distributions
+        return None
+
+    def test_full(self):
+        # TODO: full set of test cases
+        # - Tests each round of sampling
+        # - Tests for empty distributions
+        # - Tests last element is always 1.0
+        return None
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Makefile includes small updates for formatting. Caught small bug in init(). Added sample1() function which allows for sampling from current distribution 1 item at a time and returns item type instead of a list of results counts. init now includes a protocol for generating names if none are passed as arguments. the default policy is to simply make strings of numbers in the order entered, beginning with 0. Added simple tests for cdf() function and TODOs for more aggressive testing.